### PR TITLE
make mypy stricter, include py.typed for PEP 561 compliance

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,17 +1,15 @@
 [mypy]
-check_untyped_defs = True
 warn_redundant_casts = True
 warn_unused_ignores = True
+warn_no_return = True
 warn_unreachable = True
 
 # Untyped Definitions and Calls
 disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+check_untyped_defs = True
 disallow_untyped_decorators = True
-
-# None and Optional Handling
-strict_optional = True
 
 [mypy-pymongo]
 ignore_missing_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -3,8 +3,15 @@ check_untyped_defs = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 warn_unreachable = True
+
+# Untyped Definitions and Calls
+disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+
+# None and Optional Handling
+strict_optional = True
 
 [mypy-pymongo]
 ignore_missing_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,4 +1,10 @@
 [mypy]
+check_untyped_defs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unreachable = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
 
 [mypy-pymongo]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     url="https://github.com/ENOWARS/enochecker",
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},
+    package_data={"enochecker": ["py.typed"]},
     install_requires=requirements,
     classifiers=[
         # How mature is this project? Common values are

--- a/src/enochecker/enochecker.py
+++ b/src/enochecker/enochecker.py
@@ -783,7 +783,7 @@ class BaseChecker(metaclass=_CheckerMeta):
         """
         self.http_session.headers["User-Agent"] = useragent
 
-    def http_useragent_randomize(self):
+    def http_useragent_randomize(self) -> str:
         """
         Choose a new random http useragent.
 
@@ -804,7 +804,7 @@ class BaseChecker(metaclass=_CheckerMeta):
         scheme: str = "http",
         raise_http_errors: bool = False,
         timeout: Optional[int] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "requests.Response":
         """
         Perform a (http) requests.post to the current host.
@@ -832,7 +832,7 @@ class BaseChecker(metaclass=_CheckerMeta):
         scheme: str = "http",
         raise_http_errors: bool = False,
         timeout: Optional[int] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "requests.Response":
         """
         Perform a (http) requests.get to the current host.
@@ -861,7 +861,7 @@ class BaseChecker(metaclass=_CheckerMeta):
         scheme: str = "http",
         raise_http_errors: bool = False,
         timeout: Optional[int] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "requests.Response":
         """
         Perform an http request (requests lib) to the current host.

--- a/src/enochecker/nosqldict.py
+++ b/src/enochecker/nosqldict.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import MutableMapping
 from functools import wraps
 from threading import RLock, current_thread
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Union
 
 from . import utils
 from .utils import base64ify
@@ -39,9 +39,9 @@ def to_keyfmt(key: Any) -> str:
     return str(key)  # + type(key).__name__
 
 
-def _try_n_times(func):
+def _try_n_times(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
-    def try_n_times(*args, **kwargs):
+    def try_n_times(*args: Any, **kwargs: Any) -> Callable[..., Any]:
         from pymongo.errors import PyMongoError
 
         for i in range(RETRY_COUNT):
@@ -51,6 +51,7 @@ def _try_n_times(func):
                 dictlogger.error("noSQLdict_Error, Try {}".format(str(i)), exc_info=ex)
                 if i == RETRY_COUNT:
                     raise
+        assert False  # this should never happen
 
     return try_n_times
 
@@ -102,8 +103,8 @@ class NoSqlDict(MutableMapping):
         port: Union[int, str, None] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        *args,
-        **kwargs
+        *args: Any,
+        **kwargs: Any,
     ):
         """
         Initialize a NoSqlDict with specified MongoDB backend.

--- a/src/enochecker/nosqldict.py
+++ b/src/enochecker/nosqldict.py
@@ -41,7 +41,7 @@ def to_keyfmt(key: Any) -> str:
 
 def _try_n_times(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
-    def try_n_times(*args: Any, **kwargs: Any) -> Callable[..., Any]:
+    def try_n_times(*args: Any, **kwargs: Any) -> Any:
         from pymongo.errors import PyMongoError
 
         for i in range(RETRY_COUNT):

--- a/src/enochecker/storeddict.py
+++ b/src/enochecker/storeddict.py
@@ -89,8 +89,8 @@ class StoredDict(MutableMapping):
         persist_secs: int = 3,
         ignore_locks: bool = False,
         logger: Optional[logging.Logger] = None,
-        *args,
-        **kwargs
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         """
         Create a new File System backed Store.
@@ -134,7 +134,7 @@ class StoredDict(MutableMapping):
         """Spawn a thread persisting all changes, if necessary."""
         if self.persist_secs > 0 and not self._persist_thread:
 
-            def persist_async():
+            def persist_async() -> None:
                 time.sleep(self.persist_secs)
                 self.logger.debug("Persisting db {} from background.".format(self.name))
                 self.persist()

--- a/src/enochecker/storeddict.py
+++ b/src/enochecker/storeddict.py
@@ -51,7 +51,7 @@ def _locked(func: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @wraps(func)
-    def locked(self: "StoredDict", *args: str, **kwargs: int) -> Callable[..., Any]:
+    def locked(self: "StoredDict", *args: str, **kwargs: int) -> Any:
         """
         Wrap the function.
 


### PR DESCRIPTION
By including the `py.typed` this package is marked as PEP 561 compliant. This allows checkers which import the `enochecker` library to use the type annotations in their own checks.