### PR TITLE
Added retries to self.connect

### DIFF
--- a/src/enochecker/enochecker.py
+++ b/src/enochecker/enochecker.py
@@ -777,7 +777,7 @@ class BaseChecker(metaclass=_CheckerMeta):
                 host, port, timeout=timeout, logger=self.logger, timeout_fun=timeout_fun
             )
             return sock
-        except Exception as ex:
+        except socket.error as ex:
             self.debug(f"Connection to {host}:{port} failed, retrying... {ex}")
 
         # Not putting this in the exception block - else the stack trace gets looong.

--- a/src/enochecker/enochecker.py
+++ b/src/enochecker/enochecker.py
@@ -772,10 +772,9 @@ class BaseChecker(metaclass=_CheckerMeta):
             "Opening socket to {}:{} (timeout {} secs).".format(host, port, timeout)
         )
         try:
-            sock = SimpleSocket(
+            return SimpleSocket(
                 host, port, timeout=timeout, logger=self.logger, timeout_fun=timeout_fun
             )
-            return sock
         except socket.error as ex:
             self.debug(f"Connection to {host}:{port} failed, retrying... {ex}")
 

--- a/src/enochecker/enochecker.py
+++ b/src/enochecker/enochecker.py
@@ -7,7 +7,6 @@ import logging
 import os
 import socket
 import sys
-import time
 import traceback
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -37,7 +36,7 @@ from .useragents import random_useragent
 from .utils import SimpleSocket, snake_caseify
 
 if TYPE_CHECKING:  # pragma: no cover
-    # The import might fail in UWSGI, see the comments below.
+    # The import might deadlock in UWSGI, see the comments below.
     import requests
 
 DEFAULT_TIMEOUT: int = 30
@@ -173,8 +172,8 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         type=int,
         default=0,
         help="Unique numerical index per round. Each id only occurs once and is tighly packed, "
-             "starting with 0. In a service supporting multiple flags, this would be used to "
-             "decide which flag to place.",
+        "starting with 0. In a service supporting multiple flags, this would be used to "
+        "decide which flag to place.",
     )
     runparser.add_argument(
         "-j",
@@ -196,7 +195,7 @@ class _CheckerMeta(ABCMeta):
     """
 
     def __init__(
-            cls: "_CheckerMeta", name: str, bases: Tuple[type, ...], clsdict: Dict[Any, Any]
+        cls: "_CheckerMeta", name: str, bases: Tuple[type, ...], clsdict: Dict[Any, Any]
     ):
         """
         Called whenever this class is subclassed.
@@ -223,24 +222,24 @@ class BaseChecker(metaclass=_CheckerMeta):
     noise_count: int
 
     def __init__(
-            self,
-            request_dict: Dict[str, Any] = None,
-            run_id: int = None,
-            method: str = None,
-            address: str = None,
-            team: str = None,  # deprecated!
-            team_name: str = None,
-            team_id: int = None,
-            round: int = None,  # deprecated!
-            round_id: int = None,
-            flag_round: int = None,
-            round_length: int = 300,
-            flag: str = None,
-            flag_idx: int = None,
-            timeout: int = None,
-            storage_dir: str = DB_DEFAULT_DIR,
-            use_db_cache: bool = DB_GLOBAL_CACHE_SETTING,
-            json_logging: bool = True,
+        self,
+        request_dict: Dict[str, Any] = None,
+        run_id: int = None,
+        method: str = None,
+        address: str = None,
+        team: str = None,  # deprecated!
+        team_name: str = None,
+        team_id: int = None,
+        round: int = None,  # deprecated!
+        round_id: int = None,
+        flag_round: int = None,
+        round_length: int = 300,
+        flag: str = None,
+        flag_idx: int = None,
+        timeout: int = None,
+        storage_dir: str = DB_DEFAULT_DIR,
+        use_db_cache: bool = DB_GLOBAL_CACHE_SETTING,
+        json_logging: bool = True,
     ) -> None:
         """
         Init the Checker, fill the params.
@@ -425,10 +424,10 @@ class BaseChecker(metaclass=_CheckerMeta):
                 if method == "getflag":
                     try:
                         ignore_run = not (
-                                "OK"
-                                == self.team_db[
-                                    f"__Checker-internals-RESULT:putflag,{self.flag_round},{self.flag_idx}__"
-                                ]
+                            "OK"
+                            == self.team_db[
+                                f"__Checker-internals-RESULT:putflag,{self.flag_round},{self.flag_idx}__"
+                            ]
                         )
 
                     except KeyError:
@@ -441,10 +440,10 @@ class BaseChecker(metaclass=_CheckerMeta):
                     try:
 
                         ignore_run = not (
-                                "OK"
-                                == self.team_db[
-                                    f"__Checker-internals-RESULT:putnoise,{self.flag_round},{self.flag_idx}__"
-                                ]
+                            "OK"
+                            == self.team_db[
+                                f"__Checker-internals-RESULT:putnoise,{self.flag_round},{self.flag_idx}__"
+                            ]
                         )
 
                     except KeyError:
@@ -494,15 +493,15 @@ class BaseChecker(metaclass=_CheckerMeta):
             return CheckerResult.from_exception(eno)  # , eno.message
         except self.requests.HTTPError as ex:
             self.info("Service returned HTTP Errorcode [{}].".format(ex), exc_info=ex)
-            return CheckerResult(Result.MUMBLE, "Service returned HTTP Error", )
+            return CheckerResult(Result.MUMBLE, "Service returned HTTP Error",)
         except (
-                self.requests.ConnectionError,  # requests
-                self.requests.exceptions.ConnectTimeout,  # requests
-                TimeoutError,
-                socket.timeout,
-                ConnectionError,
-                OSError,
-                ConnectionAbortedError,
+            self.requests.ConnectionError,  # requests
+            self.requests.exceptions.ConnectTimeout,  # requests
+            TimeoutError,
+            socket.timeout,
+            ConnectionError,
+            OSError,
+            ConnectionAbortedError,
         ) as ex:
             self.info(
                 "Error in connection to service occurred: {}\n".format(ex), exc_info=ex
@@ -616,7 +615,7 @@ class BaseChecker(metaclass=_CheckerMeta):
 
     # ---- DB specific methods ---- #
     def db(
-            self, name: str, ignore_locks: bool = False
+        self, name: str, ignore_locks: bool = False
     ) -> Union[NoSqlDict, StoredDict]:  # TODO: use a common supertype for all backends
         """
         Get a (global) db by name.
@@ -677,7 +676,7 @@ class BaseChecker(metaclass=_CheckerMeta):
 
     @property
     def global_db(
-            self,
+        self,
     ) -> Union[NoSqlDict, StoredDict]:  # TODO: use a common supertype for all backends
         """
         Get a global storage shared between all teams and rounds.
@@ -691,7 +690,7 @@ class BaseChecker(metaclass=_CheckerMeta):
 
     @property
     def team_db(
-            self,
+        self,
     ) -> Union[NoSqlDict, StoredDict]:  # TODO: use a common supertype for all backends
         """
         Return the database for the current team.
@@ -701,7 +700,7 @@ class BaseChecker(metaclass=_CheckerMeta):
         return self.get_team_db()
 
     def get_team_db(
-            self, team: Optional[str] = None
+        self, team: Optional[str] = None
     ) -> Union[NoSqlDict, StoredDict]:  # TODO: use a common supertype for all backends
         """
         Return the database for a specific team.
@@ -716,7 +715,7 @@ class BaseChecker(metaclass=_CheckerMeta):
 
     # ---- Networking specific methods ---- #
     def _sanitize_url(
-            self, route: str, port: Optional[int] = None, scheme: Optional[str] = None
+        self, route: str, port: Optional[int] = None, scheme: Optional[str] = None
     ) -> str:
         if port is None:
             port = self.port
@@ -735,11 +734,11 @@ class BaseChecker(metaclass=_CheckerMeta):
         return url._replace(netloc=netloc).geturl()
 
     def connect(
-            self,
-            host: Optional[str] = None,
-            port: Optional[int] = None,
-            timeout: Optional[int] = None,
-            retries: Optional[int] = 1,
+        self,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        timeout: Optional[int] = None,
+        retries: Optional[int] = 1,
     ) -> SimpleSocket:
         """
         Open a socket/telnet connection to the remote host.
@@ -817,14 +816,14 @@ class BaseChecker(metaclass=_CheckerMeta):
         return new_agent
 
     def http_post(
-            self,
-            route: str = "/",
-            params: Any = None,
-            port: Optional[int] = None,
-            scheme: str = "http",
-            raise_http_errors: bool = False,
-            timeout: Optional[int] = None,
-            **kwargs: Any,
+        self,
+        route: str = "/",
+        params: Any = None,
+        port: Optional[int] = None,
+        scheme: str = "http",
+        raise_http_errors: bool = False,
+        timeout: Optional[int] = None,
+        **kwargs: Any,
     ) -> "requests.Response":
         """
         Perform a (http) requests.post to the current host.
@@ -845,14 +844,14 @@ class BaseChecker(metaclass=_CheckerMeta):
         )
 
     def http_get(
-            self,
-            route: str = "/",
-            params: Any = None,
-            port: Optional[int] = None,
-            scheme: str = "http",
-            raise_http_errors: bool = False,
-            timeout: Optional[int] = None,
-            **kwargs: Any,
+        self,
+        route: str = "/",
+        params: Any = None,
+        port: Optional[int] = None,
+        scheme: str = "http",
+        raise_http_errors: bool = False,
+        timeout: Optional[int] = None,
+        **kwargs: Any,
     ) -> "requests.Response":
         """
         Perform a (http) requests.get to the current host.
@@ -873,15 +872,15 @@ class BaseChecker(metaclass=_CheckerMeta):
         )
 
     def http(
-            self,
-            method: str,
-            route: str = "/",
-            params: Any = None,
-            port: Optional[int] = None,
-            scheme: str = "http",
-            raise_http_errors: bool = False,
-            timeout: Optional[int] = None,
-            **kwargs: Any,
+        self,
+        method: str,
+        route: str = "/",
+        params: Any = None,
+        port: Optional[int] = None,
+        scheme: str = "http",
+        raise_http_errors: bool = False,
+        timeout: Optional[int] = None,
+        **kwargs: Any,
     ) -> "requests.Response":
         """
         Perform an http request (requests lib) to the current host.
@@ -915,7 +914,7 @@ class BaseChecker(metaclass=_CheckerMeta):
 
 
 def run(
-        checker_cls: Type[BaseChecker], args: Optional[Sequence[str]] = None,
+    checker_cls: Type[BaseChecker], args: Optional[Sequence[str]] = None,
 ) -> Optional[CheckerResult]:
     """
     Run a checker, either from cmdline or as uwsgi script.


### PR DESCRIPTION
The requests library internally retries each connection 1000 times or so.
The telnet lib, however, doesn't.
If a minor load spike in some obscure service occurs, the checker should have an option to retry easily.