### PR TITLE
Remove `serve_once` and deamon-specific options from utils.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: all lint diff format test
+
+all: format test
+
 lint:
 	python3 -m isort -c src/ tests/ example/
 	python3 -m black --check src/ tests/ example/
@@ -13,6 +17,6 @@ format:
 	python3 -m black src/ tests/ example/
 
 test:
-	pip install .
+	pip3 install .
 	coverage run -m pytest
 	coverage report -m

--- a/docs/api.md
+++ b/docs/api.md
@@ -323,30 +323,6 @@ Will raise an exception if failed.
 :param timeout: a timeout
 :return read: the bytes read
 
-## start_daemon
-```python
-start_daemon(target)
-```
-
-starts a thread as daemon
-:param target: the function
-:return: the started thread
-
-## serve_once
-```python
-serve_once(html, start_port=5000, autoincrement_port=True, content_type='text/html', headers=None)
-```
-
-Render Text in the users browser
-Opens a web server that serves a HTML string once and shuts down after the first request.
-The port will be open when this function returns. (though serving the request may take a few mils)
-:param html: The html code to deliver on the initial request
-:param start_port: The port it should try to listen on first.
-:param autoincrement_port: If the port should be increased if the server cannot listen on the provided start_port
-:param content_type: The content type this server should report (change it if you want json, for example)
-:param headers: Additional headers as {header_key: value} dict.
-:return: The port the server started listening on
-
 ## SimpleSocket
 ```python
 SimpleSocket(self, host=None, port=0, timeout=<object object at 0x000000000303A670>)

--- a/src/enochecker/__init__.py
+++ b/src/enochecker/__init__.py
@@ -14,10 +14,8 @@ from .utils import (  # the util stuff
     ensure_bytes,
     ensure_unicode,
     ensure_valid_filename,
-    serve_once,
     sha256ify,
     snake_caseify,
-    start_daemon,
 )
 
 name = "enochecker"

--- a/src/enochecker/utils.py
+++ b/src/enochecker/utils.py
@@ -6,17 +6,7 @@ import logging
 import re
 import socket
 import telnetlib
-from typing import (
-    Any,
-    Callable,
-    List,
-    Match,
-    Optional,
-    Pattern,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, List, Match, Optional, Pattern, Sequence, Tuple, Union
 
 from .results import BrokenServiceException
 

--- a/src/enochecker/utils.py
+++ b/src/enochecker/utils.py
@@ -7,10 +7,8 @@ import re
 import socket
 import telnetlib
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     List,
     Match,
     Optional,
@@ -21,9 +19,6 @@ from typing import (
 )
 
 from .results import BrokenServiceException
-
-if TYPE_CHECKING:  # pragma: no cover
-    import requests
 
 PORT_MAX = 65535
 

--- a/tests/test_enochecker.py
+++ b/tests/test_enochecker.py
@@ -2,7 +2,6 @@
 import functools
 import sys
 import tempfile
-import time
 from logging import DEBUG
 
 import pytest
@@ -17,7 +16,6 @@ from enochecker import (
     assert_in,
     ensure_bytes,
     ensure_unicode,
-    serve_once,
     snake_caseify,
 )
 

--- a/tests/test_enochecker.py
+++ b/tests/test_enochecker.py
@@ -169,29 +169,6 @@ def test_dict():
 
 
 @temp_storage_dir
-def test_checker_connections():
-    # TODO: Check timeouts?
-    text = "ECHO :)"
-    _ = serve_once(text, 9999)
-    checker = CheckerExampleImpl(
-        CheckerMethod.CHECKER_METHOD_PUTFLAG,
-    )  # Conflict between logging and enochecker.logging because of wildcart import
-    assert (
-        checker.http_get("/").text == text
-    )  # Should probably rename it to enologger to avoid further conflicts
-
-    # Give server time to shut down
-    time.sleep(0.2)
-
-    _ = serve_once(text, 9999)
-    checker = CheckerExampleImpl(CheckerMethod.CHECKER_METHOD_PUTFLAG)
-    t = checker.connect()
-    t.write(b"GET / HTTP/1.0\r\n\r\n")
-    assert t.readline_expect("HTTP")
-    t.close()
-
-
-@temp_storage_dir
 def test_checker():
     flag = "ENOFLAG"
     task_chain_id = "test_task_chain_id"


### PR DESCRIPTION
Currently, utils.py has some fancy features nobody ended up using.
Especially, `serve_once` should be removed - it opens a webpage that can be used be exactly once.
I don't think we have checkers that use it, and as far as servers go, we moved to flask a long time ago.
https://github.com/enowars/enochecker/blob/30e0024bff7c07f03143241ef3c01de9650f55e6/src/enochecker/utils.py#L197
On top, `deamonize` can be dropped, as it's no longer hard to do on python3 (and should be avoided in checkers at all cost)