### PR TITLE
Remove ensure_unicode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -259,11 +259,7 @@ Raises an exception if o1 != o2
 ensure_bytes(obj)
 ```
 Converts to bytes
-## ensure_unicode
-```python
-ensure_unicode(obj)
-```
-Converts to utf-8
+
 ## ensure_valid_filename
 ```python
 ensure_valid_filename(s, min_length=3)

--- a/src/enochecker/__init__.py
+++ b/src/enochecker/__init__.py
@@ -12,7 +12,6 @@ from .utils import (  # the util stuff
     base64ify,
     debase64ify,
     ensure_bytes,
-    ensure_unicode,
     ensure_valid_filename,
     sha256ify,
     snake_caseify,

--- a/src/enochecker/utils.py
+++ b/src/enochecker/utils.py
@@ -84,22 +84,6 @@ def ensure_bytes(obj: Union[bytes, str, Any]) -> bytes:
     return str(obj).encode("utf-8")
 
 
-def ensure_unicode(obj: Union[bytes, str, Any]) -> str:
-    """
-    Convert an object to an utf-8-encoded string.
-
-    :param obj: str or bytes (or anything else) to convert to string representation
-    :return: the string representation of the object
-    """
-    if obj is None:
-        raise ValueError("Cannot stringify None")
-    if isinstance(obj, bytes):
-        return obj.decode("utf-8")
-    if isinstance(obj, str):
-        return obj
-    return str(obj)
-
-
 def ensure_valid_filename(s: str, min_length: int = 3) -> str:
     """
     Get a valid file name from the input.
@@ -117,14 +101,13 @@ def ensure_valid_filename(s: str, min_length: int = 3) -> str:
     return s
 
 
-def snake_caseify(camel: Union[str, bytes]) -> str:
+def snake_caseify(camel: str) -> str:
     """
     Turn camels into snake (-cases).
 
     :param camel: camelOrSnakeWhatever
     :return: camel_or_snake_whatever
     """
-    camel = ensure_unicode(camel)
     half_snake = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel)
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", half_snake).lower()
 

--- a/tests/test_enochecker.py
+++ b/tests/test_enochecker.py
@@ -15,7 +15,6 @@ from enochecker import (
     assert_equals,
     assert_in,
     ensure_bytes,
-    ensure_unicode,
     snake_caseify,
 )
 
@@ -120,9 +119,7 @@ def test_assert_equals():
 def test_conversions():
     assert isinstance(ensure_bytes("test"), bytes)
     assert isinstance(ensure_bytes(b"test"), bytes)
-    assert isinstance(ensure_unicode("test"), type(""))
-    assert isinstance(ensure_unicode(b"test"), type(""))
-    assert ensure_unicode(ensure_bytes("test")) == "test"
+    assert ensure_bytes("test").decode() == "test"
 
 
 def test_assert_in():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,6 @@ from enochecker.utils import (
     base64ify,
     debase64ify,
     ensure_bytes,
-    ensure_unicode,
     ensure_valid_filename,
     sha256ify,
     snake_caseify,
@@ -58,15 +57,6 @@ def test_ensure_bytes():
     assert ensure_bytes(b"a") == b"a"
     assert ensure_bytes("a") == b"a"
     assert ensure_bytes(1) == b"1"
-
-
-def test_ensure_unicode():
-    with pytest.raises(ValueError):
-        ensure_unicode(None)
-
-    assert ensure_unicode(b"a") == "a"
-    assert ensure_unicode("a") == "a"
-    assert ensure_unicode(1) == "1"
 
 
 def test_ensure_valid_filename():


### PR DESCRIPTION
This PR removes the `ensure_unicode` method, a relict from python2 days with no benefits, only footguns.
This was discussed in #107 