### PR TITLE
fixed write (issue #112)

### DIFF
--- a/src/enochecker/utils.py
+++ b/src/enochecker/utils.py
@@ -318,7 +318,7 @@ class SimpleSocket(telnetlib.Telnet):
         May raise socket.error if the connection is closed.
 
         This overwrites `Telnetlib`'s `write` function, as it
-        would otherwise double the `IAC` (0x255) character...
+        would otherwise double the `IAC` (0xFF) character...
 
         :param buffer: The buffer to write
         """

--- a/src/enochecker/utils.py
+++ b/src/enochecker/utils.py
@@ -317,6 +317,10 @@ class SimpleSocket(telnetlib.Telnet):
         Can block if the connection is blocked.
         May raise socket.error if the connection is closed.
 
+        This overwrites `Telnetlib`'s `write` function, as it
+        would otherwise double the `IAC` (0x255) character...
+
         :param buffer: The buffer to write
         """
-        super().write(ensure_bytes(buffer))
+        self.msg("send %r", buffer)
+        self.sock.sendall(ensure_bytes(buffer))

--- a/src/enochecker/utils.py
+++ b/src/enochecker/utils.py
@@ -323,4 +323,4 @@ class SimpleSocket(telnetlib.Telnet):
         :param buffer: The buffer to write
         """
         self.msg("send %r", buffer)
-        self.sock.sendall(ensure_bytes(buffer))
+        self.socket.sendall(ensure_bytes(buffer))


### PR DESCRIPTION
This PR replaces Telnetlib's `write` function with a direct call to `sock.sendall`, see  #112.