### PR TITLE
use bson instead of json in StoredDict

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -38,3 +38,6 @@ disallow_untyped_decorators = False
 [mypy-pwnlib]
 ignore_missing_imports = True
 
+[mypy-bson]
+ignore_missing_imports = True
+

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt", "r") as f:
 
 setuptools.setup(
     name="enochecker",
-    version="0.4.0",
+    version="0.4.1",
     author="domenukk",
     author_email="dmaier@sect.tu-berlin.de",
     description="Library to build checker scripts for EnoEngine A/D CTF Framework in Python",

--- a/tests/test_enochecker.py
+++ b/tests/test_enochecker.py
@@ -171,6 +171,20 @@ def test_dict():
     assert len(db) == 0
 
 
+@pytest.mark.parametrize(
+    "value", [b"binarydata", {"test": b"test", "test2": 123}, ["asd", 123, b"xyz"]]
+)
+@temp_storage_dir
+def test_storeddict_complex_types(value):
+    db = enochecker.storeddict.StoredDict(name="test", base_path=STORAGE_DIR)
+
+    db["test"] = value
+    db.persist()
+
+    db.reload()
+    assert db["test"] == value
+
+
 @temp_storage_dir
 def test_checker():
     flag = "ENOFLAG"


### PR DESCRIPTION
most notably `bytes` is not JSON-serializable. Since the NoSQLDict/MongoDB uses bson internally, this way, the behavior of StoredDict and NoSQLDict should be identical. Note that the value must be stored in a dict, since bson does not allow serializing values which are not a mapping type.