### PR TITLE
Deny DB Access for Exploits

### DIFF
--- a/src/enochecker/enochecker.py
+++ b/src/enochecker/enochecker.py
@@ -494,6 +494,8 @@ class BaseChecker(metaclass=_CheckerMeta):
     def exploit(self) -> str:
         """
         Use this method strictly for testing purposes.
+        It should run exploits just like a real team would.
+        It may not use stored data.
 
         Will hopefully not be called during the actual CTF.
 
@@ -545,6 +547,10 @@ class BaseChecker(metaclass=_CheckerMeta):
                 Manual locking ist still possible.
         :return: A dict that will be self storing. Alternatively,
         """
+        if self.method == CheckerMethod.EXPLOIT:
+            raise EnoException(
+                "The exploit method must not rely on stored data! Database access prevented."
+            )
         try:
             db = self._active_dbs[name]
             db.logger = self.logger

--- a/tests/test_enochecker.py
+++ b/tests/test_enochecker.py
@@ -14,7 +14,6 @@ import enochecker
 from enochecker import (
     BaseChecker,
     BrokenServiceException,
-    EnoException,
     OfflineException,
     assert_equals,
     assert_in,

--- a/tests/test_enochecker.py
+++ b/tests/test_enochecker.py
@@ -14,6 +14,7 @@ import enochecker
 from enochecker import (
     BaseChecker,
     BrokenServiceException,
+    EnoException,
     OfflineException,
     assert_equals,
     assert_in,
@@ -310,6 +311,18 @@ def test_return_attack_info():
     result = checker.run()
     assert result.result == CheckerTaskResult.OK
     assert result.attack_info == attack_info
+
+
+@temp_storage_dir
+def test_exploit_access_db():
+    def exploitfn(self: CheckerExampleImpl):
+        _ = self.team_db["asd"]
+
+    setattr(CheckerExampleImpl, "exploit", exploitfn)
+    checker = CheckerExampleImpl(method="exploit")
+
+    result = checker.run()
+    assert result.result == CheckerTaskResult.INTERNAL_ERROR
 
 
 @pytest.mark.nosqldict


### PR DESCRIPTION
This PR denies DB access for the `exploit` method.
In general, this is fine, the only issue I see is that, right now, we don't expose any way to use `attackinfo` in exploits. Maybe users need the db to emulate `attackinfo` for now?